### PR TITLE
Fix build warnings

### DIFF
--- a/dsp/SimdBlocks.h
+++ b/dsp/SimdBlocks.h
@@ -2,7 +2,7 @@
 
 #include "asserts.h"
 
-//#include <simd/vector.hpp>
+//#include <simd/Vector.hpp>
 //#include <simd/functions.hpp>
 #include "SqMath.h"
 

--- a/dsp/filters/ButterworthFilterDesigner.cpp
+++ b/dsp/filters/ButterworthFilterDesigner.cpp
@@ -123,7 +123,7 @@ template class ButterworthFilterDesigner<double>;
 template class ButterworthFilterDesigner<float>;
 
 #if 1
-//#include <simd/vector.hpp>
+//#include <simd/Vector.hpp>
 //#include <simd/functions.hpp>
 #include "simd.h"
 

--- a/dsp/generators/BasicVCO.h
+++ b/dsp/generators/BasicVCO.h
@@ -6,7 +6,7 @@
 #include "SqPort.h"
 #include "dsp/approx.hpp"
 #include "dsp/minblep.hpp"
-#include "simd/vector.hpp"
+#include "simd/Vector.hpp"
 #include "simd/functions.hpp"
 
 #include "ObjectCache.h"

--- a/dsp/samp/SInstrument.cpp
+++ b/dsp/samp/SInstrument.cpp
@@ -4,7 +4,7 @@
 #include "SqLog.h"
 
 void SInstrument::_dump() {
-    const int hsize = headings.size();
+    //const int hsize = headings.size();
     //SQINFO("Num Headings = %d", hsize);
     for (auto h : headings) {
         //SQINFO("--h:");

--- a/midi/controller/MidiTrackPlayer.cpp
+++ b/midi/controller/MidiTrackPlayer.cpp
@@ -106,11 +106,11 @@ void MidiTrackPlayer::reset(bool resetGates, bool resetSectionIndex) {
 MidiTrackPlayer::MidiTrackPlayer(
     std::shared_ptr<IMidiPlayerHost4> host,
     int trackIndex, 
-    std::shared_ptr<MidiSong4> _song) : constTrackIndex(trackIndex),
+    std::shared_ptr<MidiSong4> _song) : host(host),
+                                        constTrackIndex(trackIndex),
                                         voiceAssigner(voices, 16),
                                         cv0Trigger(false),
-                                        cv1Trigger(false),
-                                        host(host) {
+                                        cv1Trigger(false) {
     setSong(_song, trackIndex);
     for (int i = 0; i < 16; ++i) {
         MidiVoice& vx = voices[i];

--- a/sqsrc/clock/TriggerSequencer.h
+++ b/sqsrc/clock/TriggerSequencer.h
@@ -75,11 +75,9 @@ public:
 
             double newDelayMetric = double(newDelayPPQ) / double(StochasticNote::ppq);
             nextEventTimeMetric = newDelayMetric;
-            if (nextEventTimeMetric > 0) {
+            //if (nextEventTimeMetric > 0) {
                 //SQINFO("data not at zero, %f", nextEventTimeMetric);
-            }
-        } else {
-            nextEventTimeMetric;
+            //}
         }
     }
 
@@ -140,7 +138,6 @@ private:
 
 inline void TriggerSequencer::playOnce(double metricTime, float quantizeInterval) {
     //SQINFO("TSeq::play once, metric %f", metricTime);
-    bool didClock = false;
 
     // const double delayMetricQuantized = TimeUtils::quantize(delayMetric, quantizeInterval, true);
     const double eventTimeMetricQuantized = TimeUtils::quantize(nextEventTimeMetric, quantizeInterval, true);

--- a/sqsrc/grammar/StochasticProductionRule.cpp
+++ b/sqsrc/grammar/StochasticProductionRule.cpp
@@ -146,7 +146,7 @@ bool StochasticProductionRule::isGrammarValid(const StochasticGrammar& grammar) 
     }
 
     if (rulesHit.size() != grammar.size()) {
-        const int gsize = int(grammar.size());
+        //const int gsize = int(grammar.size());
         //SQINFO("didn't hit all rules g=%d found%d", gsize, int(rulesHit.size()));
         return false;
     }

--- a/sqsrc/grammar/StochasticProductionRule.h
+++ b/sqsrc/grammar/StochasticProductionRule.h
@@ -58,9 +58,9 @@ StochasticProductionRuleEntry::duration() const {
 inline void
 StochasticProductionRuleEntry::_dump() const {
     //SQINFO("Entry p=%f notes:", probability);
-    for (auto note : rhsProducedNotes) {
+    //for (auto note : rhsProducedNotes) {
         //SQINFO("  note %d", note.duration);
-    }
+    //}
 }
 
 /**

--- a/src/C2Json.h
+++ b/src/C2Json.h
@@ -211,7 +211,7 @@ inline void C2Json::jsonToParamsOrig(json_t* rootJ, CompressorParamHolder* param
         (json_array_size(makeupsJ) < 16) ||
         (json_array_size(enabledsJ) < 16) ||
         (json_array_size(ratiosJ) < 16)) {
-        WARN("orig parameter json malformed2 %d", json_array_size(attacksJ));
+        WARN("orig parameter json malformed2 %lu", (unsigned long)json_array_size(attacksJ));
         return;
     }
 

--- a/src/ctrl/SqHelper.h
+++ b/src/ctrl/SqHelper.h
@@ -32,7 +32,7 @@ public:
      */
     static std::shared_ptr<::rack::Svg> loadSvg(const char* path, bool pathIsAbsolute = false) {
         if (pathIsAbsolute) {
-             APP->window->loadSvg(path);
+            return APP->window->loadSvg(path);
         } else {
             return APP->window->loadSvg(
                 SqHelper::assetPlugin(pluginInstance, path));

--- a/src/grammar/GMRSerialization.cpp
+++ b/src/grammar/GMRSerialization.cpp
@@ -23,7 +23,7 @@ StochasticGrammarPtr GMRSerialization::readGrammarFile(const std::string& path) 
     s.add(" ");
     s.add(error.text);
  //   fclose(file);
-    WARN(s.str().c_str());
+    WARN("%s", s.str().c_str());
 
     return nullptr;
 }

--- a/src/grammar/GrammarRulePanel.cpp
+++ b/src/grammar/GrammarRulePanel.cpp
@@ -10,8 +10,7 @@
 #include "StochasticGrammar2.h"
 #include "StochasticProductionRule.h"
 
-GrammarRulePanel::GrammarRulePanel(const Vec &pos, const Vec &size, StochasticGrammarPtr g, Module *m) : grammar(g),
-                                                                                                         module(m) {
+GrammarRulePanel::GrammarRulePanel(const Vec &pos, const Vec &size, StochasticGrammarPtr g, Module *m) : grammar(g) {
     this->box.pos = pos;
     this->box.size = size;
 

--- a/src/grammar/GrammarRulePanel.h
+++ b/src/grammar/GrammarRulePanel.h
@@ -19,6 +19,5 @@ public:
 
 private:
     StochasticGrammarPtr grammar;
-    Module *module;
     int ruleDuration = 0;
 };

--- a/src/grammar/RuleRowEditor.h
+++ b/src/grammar/RuleRowEditor.h
@@ -29,6 +29,5 @@ private:
     StochasticProductionRuleEntryPtr entry;
     std::string ruleText;
 
-    int ct = 0;
-   // void dump(const char* title) const;
+    // void dump(const char* title) const;
 };

--- a/src/kbd/KeyMapping.cpp
+++ b/src/kbd/KeyMapping.cpp
@@ -68,7 +68,7 @@ KeyMapping::KeyMapping(const std::string& configPath)
         s.add(" ");
         s.add(error.text);
         fclose(file);
-        INFO(s.str().c_str());
+        INFO("%s", s.str().c_str());
         return;
     }
     JSONcloser cl(mappingJson, file);
@@ -89,14 +89,14 @@ KeyMapping::KeyMapping(const std::string& configPath)
                     s.add("Bad binding entry (");
                     s.add(json_dumps(value, 0));
                     s.add(")");
-                    INFO(s.str().c_str());
+                    INFO("%s", s.str().c_str());
                     return;
                 }
                 if (theMap.find(*key) != theMap.end()) {
                     SqStream s;
                     s.add("duplicate key mapping: ");
                     s.add(json_dumps(value, 0));
-                    INFO(s.str().c_str());
+                    INFO("%s", s.str().c_str());
                     return;
                 }
                 theMap[*key] = act;
@@ -128,7 +128,7 @@ KeyMapping::KeyMapping(const std::string& configPath)
                 SqStream s;
                 s.add("bad key in ignore_case: ");
                 s.add(json_dumps(value, 0));
-                INFO(s.str().c_str());
+                INFO("%s", s.str().c_str());
                 return;
             }
             std::string key = json_string_value(value);
@@ -147,7 +147,7 @@ KeyMapping::KeyMapping(const std::string& configPath)
             SqStream s;
             s.add("use_defaults is not true or false, is");
             s.add(json_dumps(useDefaultsJ, 0));
-            INFO(s.str().c_str());
+            INFO("%s", s.str().c_str());
             return;
         }
         _useDefaults = json_is_true(useDefaultsJ);
@@ -160,7 +160,7 @@ KeyMapping::KeyMapping(const std::string& configPath)
             SqStream s;
             s.add("grab_keys is not true or false, is");
             s.add(json_dumps(grabKeysJ, 0));
-            INFO(s.str().c_str());
+            INFO("%s", s.str().c_str());
             return;
         }
         _grabKeys = json_is_true(grabKeysJ);

--- a/src/seq/ClockFinder.cpp
+++ b/src/seq/ClockFinder.cpp
@@ -382,7 +382,7 @@ void ClockFinder::go(ModuleWidget* host, int div, int clockInput, int runInput, 
     assert(inputs.size() == 3);
 
     if (outputs.size() != 3 || inputs.size() != 3) {
-        WARN("bad I/O matchup. o=%d, i=%d", outputs.size(), inputs.size());
+        WARN("bad I/O matchup. o=%lu, i=%lu", (unsigned long)outputs.size(), (unsigned long)inputs.size());
         return;
     }
 

--- a/src/seq/NoteDisplay.cpp
+++ b/src/seq/NoteDisplay.cpp
@@ -396,7 +396,7 @@ bool NoteDisplay::handleKey(int key, int mods, int action) {
         handled = MidiKeyboardHandler::handle(sequencer, key, mods);
 #endif
         if (handled) {
-            APP->event->setSelected(this);
+            APP->event->setSelectedWidget(this);
         }
     }
     return handled;

--- a/src/seq/S4ButtonGrid.cpp
+++ b/src/seq/S4ButtonGrid.cpp
@@ -56,7 +56,7 @@ void S4ButtonGrid::init(Sequencer4Widget* parent, rack::engine::Module* module,
         const float y = grid_y + row * (buttonSize + buttonMargin);
         for (int col = 0; col < MidiSong4::numSectionsPerTrack; ++col) {
             const float x = grid_x + col * (buttonSize + buttonMargin);
-            const int padNumber = row * MidiSong4::numSectionsPerTrack + col;
+            //const int padNumber = row * MidiSong4::numSectionsPerTrack + col;
 
 
             S4Button* button = new S4Button(

--- a/test/simd_testBiquad.cpp
+++ b/test/simd_testBiquad.cpp
@@ -14,7 +14,7 @@
 #include "BiquadState.h"
 #include "IIRDecimator.h"
 
-#include <simd/vector.hpp>
+#include <simd/Vector.hpp>
 #include <simd/functions.hpp>
 
 using float_4 = rack::simd::float_4;


### PR DESCRIPTION
Fixes the build warnings present on my Windows 10 msys2 build.
Also fixed some additional ones I saw from issue #2 .

Only one was potentially an issue - loadSvg wasn't returning a value if an absolute path was specified.
The others didn't seem bad, mainly unused variables.