### PR TITLE
Adjust brightness of SVG lights

### DIFF
--- a/src/ctrl/SqToggleLED.h
+++ b/src/ctrl/SqToggleLED.h
@@ -45,6 +45,7 @@ private:
     int getSvgIndex();
 
     bool isDragging = false;
+    const float luminosity = 7.f/12.f;
 };
 
 inline void SqToggleLED::setHandler(callback h)
@@ -77,6 +78,9 @@ inline int SqToggleLED::getSvgIndex()
 inline void SqToggleLED::drawLayer(const DrawArgs &args, int layer)
 {
     if (layer == 1) {
+        // Scale from max brightness to min brightness, as rack brightness is reduced from one to zero
+        nvgAlpha(args.vg, (1.f - luminosity) * rack::settings::rackBrightness + luminosity);
+
         int index = getSvgIndex();
         auto svg = svgs[index];
         svg->draw(args);

--- a/src/ctrl/ToggleButton.h
+++ b/src/ctrl/ToggleButton.h
@@ -48,10 +48,15 @@ public:
 
     void drawLayer(const DrawArgs& args,int layer) override {
 	    if (layer ==1) {
+            // Scale from max brightness to min brightness, as rack brightness is reduced from one to zero
+            nvgAlpha(args.vg, (1.f - luminosity) * rack::settings::rackBrightness + luminosity);
+
             ::rack::app::SvgSwitch::draw(args);
         }
         SvgSwitch::drawLayer(args,layer);
     }
+private:
+    const float luminosity = 7.f/12.f;
 };
 
 #else

--- a/src/ctrl/ToggleButtonV1.h
+++ b/src/ctrl/ToggleButtonV1.h
@@ -111,6 +111,7 @@ private:
 
     bool didStep = false;
     bool isControlKey = false;
+    const float luminosity = 4.f/9.f;
 };
 
 
@@ -166,6 +167,8 @@ inline float SqSvgParamToggleButton::getValue()
 inline void SqSvgParamToggleButton::drawLayer(const DrawArgs &args, int layer)
 {
     if (layer == 1) {
+        // Scale from max brightness to min brightness, as rack brightness is reduced from one to zero
+        nvgAlpha(args.vg, (1.f - luminosity) * rack::settings::rackBrightness + luminosity);
         button->draw(args);
     }
     ParamWidget::drawLayer(args,layer);


### PR DESCRIPTION
I use Kitchen Sink often, and found the new v2 lit buttons to be uncomfortably bright when Rack brightness is reduced-- especially the white ones.

This PR scales the brightness (alpha) of these SVG-lights from maximum to a hard-coded minimum as Rack brightness is reduced from maximum to zero. This way, the SVGs render as normal when the "room lights" are bright, and as the room lights dim the "underlying LED brightness" of the buttons is revealed.

This roughly approximates the behavior of a frosted surface with soft back-lighting; in daylight conditions, the ambient light reflected by the surface is greater than the light produced from the LED.