### PR TITLE
use new PopupMenuParamWidget from SqHarmony

### DIFF
--- a/src/seq/InputControls.cpp
+++ b/src/seq/InputControls.cpp
@@ -11,18 +11,18 @@ void InputPopupMenuParamWidget::draw(const Widget::DrawArgs &args)
 void InputPopupMenuParamWidget::setValue(float v)
 {
     int i = int(std::round(v));
-    if (i < 0 || i >= int(labels.size())) {
+    if (i < 0 || i >= int(longLabels.size())) {
         WARN("popup set value illegal");
         assert(false);
         return;
     }
-    this->text = labels[i];
+    this->text = longLabels[i];
 }
 
 float InputPopupMenuParamWidget::getValue() const
 {
     int index = 0;
-    for (auto label : labels) {
+    for (auto label : longLabels) {
        // DEBUG("comparing label >%s< to this >%s<", label.c_str(), this->text.c_str());
         if (this->text == label) {
          //   DEBUG("found match");


### PR DESCRIPTION
work in progress, brining enhanced popup widget from SqHarmony.
This one fixes a broken undo.
This one fixed midi parameter mapping.
adds a set of optional short labels that can be used then the menu is closed (to save panel space).

As you can see in the PR notes, the name of the new undo event is perhaps not great.