### PR TITLE
Changes to build ARM64

### DIFF
--- a/composites/MixM.h
+++ b/composites/MixM.h
@@ -2,7 +2,11 @@
 #pragma once
 
 #include <assert.h>
+#if ARCH_ARM64
+#include "arm_intrinsics_sub.h"
+#else
 #include <immintrin.h>
+#endif
 
 #include <memory>
 

--- a/dsp/filters/MultiLag.h
+++ b/dsp/filters/MultiLag.h
@@ -6,8 +6,12 @@
 
 #include <assert.h>
 #include <cmath>
+#if ARCH_ARM64
+#include "arm_intrinsics_sub.h"
+#else
 #include <xmmintrin.h>
 #include <mmintrin.h>
+#endif
 
 #define _LLOOK
 #define _LPSSE

--- a/dsp/third-party/src/SqMath.h
+++ b/dsp/third-party/src/SqMath.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "rack.hpp"
+#if ARCH_ARM64
+#include "arm_intrinsics_sub.h"
+#else
 #include <immintrin.h>
+#endif
 #include <random>
 #if !defined(M_PI)
 #define M_PI float(3.14159265358979323846264338327950288)

--- a/dsp/utils/LookupTable.h
+++ b/dsp/utils/LookupTable.h
@@ -7,7 +7,11 @@
 #include <assert.h>
 #include <cmath>
 #include <memory>
+#if ARCH_ARM64
+#include "arm_intrinsics_sub.h"
+#else
 #include <emmintrin.h>
+#endif
 #include <functional>
 
 template <typename T> class LookupTableParams;

--- a/dsp/utils/arm_intrinsics_sub.h
+++ b/dsp/utils/arm_intrinsics_sub.h
@@ -1,0 +1,19 @@
+/*
+ * This file is included in ARCH_ARM64 to provide the various SIMDE intrinsics
+ */
+
+/*
+ * Approach 1: Recommended by andrew. Just include rack.hpp. 
+ */
+#include "rack.hpp"
+
+
+/*
+ * Approach 2: If you want we can also include simde directly.That would involve a statement like
+
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
+
+ * which would allow this code to ahve just simde as a dependency. But since it seems we are rack bound
+ * all the way into this dsp code, the rack.hpp is the most stable approach
+ */


### PR DESCRIPTION
These changes allow the code to build with Rack-ARM api and run in rack free for ARM on my M1.

They really are just sybbing out the direct includes of the intrinsics with rack.hpp but see the comment in arm_intrinsics_sub for a different stragegy you may want.